### PR TITLE
fix(crons): set cron name

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ terraform {
   required_providers {
     scaleway = {
       source  = "scaleway/scaleway"
-      version = ">= 2.35.0"
+      version = ">= 2.36.0"
     }
   }
 }
@@ -174,18 +174,18 @@ a_folder_to_ignore
 <!-- BEGIN_TF_DOCS -->
 ### Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | >= 2.35.0 |
+| Name | Version   |
+|------|-----------|
+| <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | >= 2.36.0 |
 
 ### Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
-| <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | >= 2.35.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+| Name | Version   |
+|------|-----------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a       |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a       |
+| <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | >= 2.36.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a       |
 
 ### Modules
 

--- a/README.md
+++ b/README.md
@@ -174,18 +174,18 @@ a_folder_to_ignore
 <!-- BEGIN_TF_DOCS -->
 ### Requirements
 
-| Name | Version   |
-|------|-----------|
+| Name | Version |
+|------|---------|
 | <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | >= 2.36.0 |
 
 ### Providers
 
-| Name | Version   |
-|------|-----------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a       |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a       |
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 | <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | >= 2.36.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | n/a       |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ### Modules
 

--- a/containers.tf
+++ b/containers.tf
@@ -54,8 +54,7 @@ resource "scaleway_container_cron" "container_crons" {
 
   region = each.value.namespace.region
 
-  // name = each.value.cron.name // TODO: name can't be set with Terraform provider (https://github.com/scaleway/terraform-provider-scaleway/issues/2363)
-
+  name         = each.value.cron.name
   container_id = scaleway_container.containers[format("%s/%s/%s/%s", each.value.namespace.region, each.value.namespace.project_id, each.value.namespace.name, each.value.container.name)].id
   schedule     = each.value.cron.schedule
   args         = each.value.cron.args

--- a/examples/full_example/versions.tf
+++ b/examples/full_example/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     scaleway = {
       source  = "scaleway/scaleway"
-      version = "2.35.0"
+      version = "2.36.0"
     }
   }
   required_version = ">= 1.6.0"

--- a/functions.tf
+++ b/functions.tf
@@ -65,8 +65,7 @@ resource "scaleway_function_cron" "function_crons" {
 
   region = each.value.namespace.region
 
-  // name = each.value.cron.name // TODO: name can't be set with Terraform provider (https://github.com/scaleway/terraform-provider-scaleway/issues/2363)
-
+  name        = each.value.cron.name
   function_id = scaleway_function.functions[format("%s/%s/%s/%s", each.value.namespace.region, each.value.namespace.project_id, each.value.namespace.name, each.value.function.name)].id
   schedule    = each.value.cron.schedule
   args        = each.value.cron.args

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
     // required to create Scaleway resources, obviously!
     scaleway = {
       source  = "scaleway/scaleway"
-      version = ">= 2.35.0"
+      version = ">= 2.36.0"
     }
     // required to create archives for functions
     archive = {


### PR DESCRIPTION
Cron names (for both functions and containers) were not set because of this issue: https://github.com/scaleway/terraform-provider-scaleway/issues/2363.

Now, this issue is fixed:

- https://github.com/scaleway/terraform-provider-scaleway/pull/2365
- https://github.com/scaleway/terraform-provider-scaleway/pull/2366

And a new release with these fixes have been made: https://github.com/scaleway/terraform-provider-scaleway/releases/tag/v2.36.0.

So, we can bump Terraform provider version and finally uncomment `name = each.value.cron.name`!