### PR TITLE
feat(env): add an env variable for Terraform

### DIFF
--- a/examples/full_example/.scaleway_serverless_config.env.yaml
+++ b/examples/full_example/.scaleway_serverless_config.env.yaml
@@ -3,6 +3,6 @@ secret_var1: "value1"
 secret_var2: "value2"
 secret_varA: "valueA"
 secret_varB: "valueB"
-var2: "env_var_var2_value"
+var2: "" # this one will be set using module "env" variable; we set it here so the validator doesn't complain
 
 project_id: "00000000-0000-0000-0000-000000000000" # replace with a valid project id before applying!

--- a/examples/full_example/main.tf
+++ b/examples/full_example/main.tf
@@ -2,6 +2,9 @@ module "scaleway_serverless" {
   source = "git::https://github.com/norbjd/scaleway-serverless-module.git?ref=main"
 
   container_push_secret_key = var.container_push_secret_key
+  env = {
+    "var2": "env_var_var2_value",
+  }
 
   // to be able to create triggers, we just need to wait until the queues are created
   depends_on = [

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,11 @@
 locals {
   // decode the YAML file containing variables to inject into config file (using templating)
-  env = fileexists(
-    "${var.context_dir}/${var.env_filename}"
-  ) ? yamldecode(file("${var.context_dir}/${var.env_filename}")) : {}
+  // and merge with var.env
+  env = merge(
+    fileexists(
+      "${var.context_dir}/${var.env_filename}"
+    ) ? yamldecode(file("${var.context_dir}/${var.env_filename}")) : {}
+  , var.env)
 
   // the config file, templated with env defined above
   config = yamldecode(

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "env_filename" {
   description = "Name of the file used to store variables used to template the config file. This file must be located in context_dir"
 }
 
+variable "env" {
+  type        = map(string)
+  default     = {}
+  description = "Other env variables. Useful if we want to pass values from Terraform directly (and not using the env file)"
+}
+
 variable "container_push_secret_key" {
   type        = string
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "env_filename" {
 variable "env" {
   type        = map(string)
   default     = {}
-  description = "Other env variables. Useful if we want to pass values from Terraform directly (and not using the env file)"
+  description = "Other env variables. Useful if we want to pass values from Terraform directly (and not using the env file). Variables defined here take precedence over those defined in the env file if there is a conflict"
 }
 
 variable "container_push_secret_key" {


### PR DESCRIPTION
When using the module, I've noticed it was difficult to pass variables between other resources managed by Terraform and the module. Mostly because we had to rely on the env file (`.scaleway_serverless_config.env.yaml`).

So I've added a new `env` variable that is used to define variables, and is merged to the existing `.scaleway_serverless_config.env.yaml`.

Example:

```hcl
resource "scaleway_mnq_sqs_queue" "a_queue" {
  name = "a-queue"
  // ...
}

module "scaleway_serverless" {
  source = "git::https://github.com/norbjd/scaleway-serverless-module.git?ref=main"

  env = {
    "a_sqs_queue_url": scaleway_mnq_sqs_queue.a_queue.url
  }
}
```